### PR TITLE
make printf-like functions lazy

### DIFF
--- a/lib/log.mli
+++ b/lib/log.mli
@@ -55,13 +55,13 @@ module type S = sig
 
   (** {4 printf-like parameters} *)
 
-  val logf: log_level -> ('a, unit, string, unit) format4 -> 'a
+  val logf: log_level -> ('a, out_channel, unit, unit) format4 -> 'a
 
-  val fatalf : ('a, unit, string, unit) format4 -> 'a
-  val errorf : ('a, unit, string, unit) format4 -> 'a
-  val warnf: ('a, unit, string, unit) format4 -> 'a
-  val infof : ('a, unit, string, unit) format4 -> 'a
-  val debugf : ('a, unit, string, unit) format4 -> 'a
+  val fatalf : ('a, out_channel, unit, unit) format4 -> 'a
+  val errorf : ('a, out_channel, unit, unit) format4 -> 'a
+  val warnf: ('a, out_channel, unit, unit) format4 -> 'a
+  val infof : ('a, out_channel, unit, unit) format4 -> 'a
+  val debugf : ('a, out_channel, unit, unit) format4 -> 'a
 
 end
 


### PR DESCRIPTION
See issue #8 . Some code is duplicated, but not much (logf cannot use log in its implementation). Signatures of printf-like functions use out_channel rather than strings, but overall it doesn't change how the functions are used, and should be more efficient (no intermediate string).
