### PR TITLE
Simplify signatures: ('a, 'b, 'c) format = ('a, 'b, 'c, 'c) format4.

### DIFF
--- a/lib/log.ml
+++ b/lib/log.ml
@@ -126,12 +126,12 @@ let level_to_string lvl =
 let section_width = ref 0
 
 module type S = sig
-  val log   : log_level -> ('a, out_channel, unit, unit) format4 -> 'a
-  val fatal : ('a, out_channel, unit, unit) format4 -> 'a
-  val error : ('a, out_channel, unit, unit) format4 -> 'a
-  val warn  : ('a, out_channel, unit, unit) format4 -> 'a
-  val info  : ('a, out_channel, unit, unit) format4 -> 'a
-  val debug : ('a, out_channel, unit, unit) format4 -> 'a
+  val log   : log_level -> ('a, out_channel, unit) format -> 'a
+  val fatal : ('a, out_channel, unit) format -> 'a
+  val error : ('a, out_channel, unit) format -> 'a
+  val warn  : ('a, out_channel, unit) format -> 'a
+  val info  : ('a, out_channel, unit) format -> 'a
+  val debug : ('a, out_channel, unit) format -> 'a
 end
 
 module type SECTION = sig

--- a/lib/log.mli
+++ b/lib/log.mli
@@ -49,11 +49,11 @@ module type S = sig
 
   val log: log_level -> ('a, out_channel, unit, unit) format4 -> 'a
 
-  val fatal : ('a, out_channel, unit, unit) format4 -> 'a
-  val error : ('a, out_channel, unit, unit) format4 -> 'a
-  val warn  : ('a, out_channel, unit, unit) format4 -> 'a
-  val info  : ('a, out_channel, unit, unit) format4 -> 'a
-  val debug : ('a, out_channel, unit, unit) format4 -> 'a
+  val fatal : ('a, out_channel, unit) format -> 'a
+  val error : ('a, out_channel, unit) format -> 'a
+  val warn  : ('a, out_channel, unit) format -> 'a
+  val info  : ('a, out_channel, unit) format -> 'a
+  val debug : ('a, out_channel, unit) format -> 'a
 
 end
 


### PR DESCRIPTION
Make the signatures a bit easier to read by using the [`format`](https://github.com/ocaml/ocaml/blob/b40c186bfc3bb3f3099ea146618a6b674d50a47c/stdlib/pervasives.mli#L1080) type alias instead of `format4`.